### PR TITLE
Do not apply the interpolation fix when Thorium is installed.

### DIFF
--- a/src/main/java/net/id/incubus_core/mixin/Plugin.java
+++ b/src/main/java/net/id/incubus_core/mixin/Plugin.java
@@ -1,0 +1,48 @@
+package net.id.incubus_core.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public final class Plugin implements IMixinConfigPlugin {
+	
+	@Override
+	public void onLoad(String mixinPackage) {
+	}
+	
+	@Override
+	public String getRefMapperConfig() {
+		return null;
+	}
+	
+	@Override
+	public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+		if (mixinClassName.equals("net.id.incubus_core.mixin.client.InterpFixMixin")) {
+			return !FabricLoader.getInstance().isModLoaded("thorium");
+		} else {
+			return true;
+		}
+	}
+	
+	@Override
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+	}
+	
+	@Override
+	public List<String> getMixins() {
+		return List.of();
+	}
+	
+	@Override
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+	}
+	
+	@Override
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+	}
+	
+}

--- a/src/main/resources/incubus_core.mixins.json
+++ b/src/main/resources/incubus_core.mixins.json
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "package": "net.id.incubus_core.mixin",
   "compatibilityLevel": "JAVA_17",
+  "plugin": "net.id.incubus_core.mixin.Plugin",
   "mixins": [
     "IngredientMixin",
     "blocklikeentities.ServerWorldMixin",


### PR DESCRIPTION
Bug report: https://github.com/DaFuqs/Spectrum/issues/66

The mod thorium (https://www.curseforge.com/minecraft/mc-mods/thorium) makes a list of bug fixes, including the same interpolation fix. Having both mixins being applied at once tints all animated blocks blue because of overflow by combining the two mixin effects at once.