### PR TITLE
Unconcerned Matchbooks 1.19.3 edition

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx2G
 	fabric_version=0.69.1+1.19.3
 
 # Mod Properties
-	mod_version = 1.8.0
+	mod_version = 1.8.1
 	# todo change
 	maven_group = azzy.fabric
 	archives_base_name = incubus-core

--- a/src/main/java/net/id/incubus_core/recipe/matchbook/BooleanMatch.java
+++ b/src/main/java/net/id/incubus_core/recipe/matchbook/BooleanMatch.java
@@ -2,7 +2,6 @@ package net.id.incubus_core.recipe.matchbook;
 
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
 
 public class BooleanMatch extends Match {
@@ -15,9 +14,9 @@ public class BooleanMatch extends Match {
 
     @Override
     boolean matches(ItemStack stack) {
-        var nbt = stack.getOrCreateNbt();
+        var nbt = stack.getNbt();
 
-        if(nbt.contains(key)) {
+        if(nbt != null && nbt.contains(key)) {
             return nbt.getBoolean(key) == booleanValue;
         }
 

--- a/src/main/java/net/id/incubus_core/recipe/matchbook/ByteMatch.java
+++ b/src/main/java/net/id/incubus_core/recipe/matchbook/ByteMatch.java
@@ -2,7 +2,6 @@ package net.id.incubus_core.recipe.matchbook;
 
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
 
 public class ByteMatch extends Match {
@@ -15,9 +14,9 @@ public class ByteMatch extends Match {
 
     @Override
     boolean matches(ItemStack stack) {
-        var nbt = stack.getOrCreateNbt();
+        var nbt = stack.getNbt();
 
-        if(nbt.contains(key)) {
+        if(nbt != null && nbt.contains(key)) {
             return nbt.getByte(key) == targetByte;
         }
 

--- a/src/main/java/net/id/incubus_core/recipe/matchbook/EnchantmentMatch.java
+++ b/src/main/java/net/id/incubus_core/recipe/matchbook/EnchantmentMatch.java
@@ -18,9 +18,9 @@ public class EnchantmentMatch extends Match {
 
     @Override
     boolean matches(ItemStack stack) {
-        var nbt = stack.getOrCreateNbt();
+        var nbt = stack.getNbt();
 
-        if(nbt.contains(key)) {
+        if(nbt != null && nbt.contains(key)) {
             if (singular) {
 
                 return testEnchantment(nbt);

--- a/src/main/java/net/id/incubus_core/recipe/matchbook/FloatMatch.java
+++ b/src/main/java/net/id/incubus_core/recipe/matchbook/FloatMatch.java
@@ -18,9 +18,9 @@ public class FloatMatch extends Match {
 
     @Override
     boolean matches(ItemStack stack) {
-        var nbt = stack.getOrCreateNbt();
+        var nbt = stack.getNbt();
 
-        if(nbt.contains(key)) {
+        if(nbt != null && nbt.contains(key)) {
             var testFloat = nbt.getFloat(key);
             return max > testFloat && testFloat > min;
         }

--- a/src/main/java/net/id/incubus_core/recipe/matchbook/IntMatch.java
+++ b/src/main/java/net/id/incubus_core/recipe/matchbook/IntMatch.java
@@ -2,7 +2,6 @@ package net.id.incubus_core.recipe.matchbook;
 
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
 
 public class IntMatch extends Match {
@@ -15,9 +14,9 @@ public class IntMatch extends Match {
 
     @Override
     boolean matches(ItemStack stack) {
-        var nbt = stack.getOrCreateNbt();
+        var nbt = stack.getNbt();
 
-        if(nbt.contains(key)) {
+        if(nbt != null && nbt.contains(key)) {
             return nbt.getInt(key) == targetInt;
         }
 

--- a/src/main/java/net/id/incubus_core/recipe/matchbook/IntRangeMatch.java
+++ b/src/main/java/net/id/incubus_core/recipe/matchbook/IntRangeMatch.java
@@ -18,9 +18,9 @@ public class IntRangeMatch extends Match {
 
     @Override
     boolean matches(ItemStack stack) {
-        var nbt = stack.getOrCreateNbt();
+        var nbt = stack.getNbt();
 
-        if(nbt.contains(key)) {
+        if(nbt != null && nbt.contains(key)) {
             var testInt = nbt.getInt(key);
             return max >= testInt && testInt >= min;
         }

--- a/src/main/java/net/id/incubus_core/recipe/matchbook/LongMatch.java
+++ b/src/main/java/net/id/incubus_core/recipe/matchbook/LongMatch.java
@@ -2,7 +2,6 @@ package net.id.incubus_core.recipe.matchbook;
 
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
 
 public class LongMatch extends Match {
@@ -15,9 +14,9 @@ public class LongMatch extends Match {
 
     @Override
     boolean matches(ItemStack stack) {
-        var nbt = stack.getOrCreateNbt();
+        var nbt = stack.getNbt();
 
-        if(nbt.contains(key)) {
+        if(nbt != null && nbt.contains(key)) {
             return nbt.getLong(key) == targetLong;
         }
 

--- a/src/main/java/net/id/incubus_core/recipe/matchbook/ShortMatch.java
+++ b/src/main/java/net/id/incubus_core/recipe/matchbook/ShortMatch.java
@@ -2,7 +2,6 @@ package net.id.incubus_core.recipe.matchbook;
 
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
 
 public class ShortMatch extends Match {
@@ -15,9 +14,9 @@ public class ShortMatch extends Match {
 
     @Override
     boolean matches(ItemStack stack) {
-        var nbt = stack.getOrCreateNbt();
+        var nbt = stack.getNbt();
 
-        if(nbt.contains(key)) {
+        if(nbt != null && nbt.contains(key)) {
             return nbt.getShort(key) == targetShort;
         }
 

--- a/src/main/java/net/id/incubus_core/recipe/matchbook/StringMatch.java
+++ b/src/main/java/net/id/incubus_core/recipe/matchbook/StringMatch.java
@@ -2,7 +2,6 @@ package net.id.incubus_core.recipe.matchbook;
 
 import com.google.gson.JsonObject;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
 
 public class StringMatch extends Match {
@@ -15,9 +14,9 @@ public class StringMatch extends Match {
 
     @Override
     boolean matches(ItemStack stack) {
-        var nbt = stack.getOrCreateNbt();
+        var nbt = stack.getNbt();
 
-        if(nbt.contains(key)) {
+        if(nbt != null && nbt.contains(key)) {
             return nbt.getString(key).equals(targetString);
         }
 


### PR DESCRIPTION
Currently, each stack getting tested in a matchbooks get's added empty `{}` nbt via `stack.getOrCreateNbt();`.
This PR mitigates that by changing them to use `getNbt()` and a null check