### PR TITLE
Minor fixes for 1.19.4

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,2 @@
-before_install:
-  - wget https://immortaldevs.net/install-jdk.sh
-  - source install-jdk.sh --feature 17
+jdk:
+  - openjdk17

--- a/src/main/java/net/id/incubus_core/IncubusCore.java
+++ b/src/main/java/net/id/incubus_core/IncubusCore.java
@@ -13,6 +13,7 @@ import net.id.incubus_core.recipe.IncubusRecipeTypes;
 import net.id.incubus_core.recipe.matchbook.IncubusMatches;
 import net.id.incubus_core.resource_conditions.IncubusCoreResourceConditions;
 import net.id.incubus_core.status_effects.ZonkedEffect;
+import net.id.incubus_core.systems.DefaultMaterials;
 import net.id.incubus_core.systems.RegistryRegistry;
 import net.id.incubus_core.util.Config;
 import net.minecraft.block.Block;
@@ -42,6 +43,7 @@ public class IncubusCore implements ModInitializer {
 			LOG.info(IncubusCoreInit.HOLY_CONST);
 
 		WorthinessChecker.init();
+		DefaultMaterials.init();
 		RegistryRegistry.init();
 		IncubusSounds.init();
 		IncubusCoreItems.init();

--- a/src/main/java/net/id/incubus_core/systems/DefaultMaterials.java
+++ b/src/main/java/net/id/incubus_core/systems/DefaultMaterials.java
@@ -4,7 +4,6 @@ import net.id.incubus_core.IncubusCore;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 
-@SuppressWarnings("unused")
 public class DefaultMaterials {
 
     public static void init() {}

--- a/src/main/java/net/id/incubus_core/systems/RegistryRegistry.java
+++ b/src/main/java/net/id/incubus_core/systems/RegistryRegistry.java
@@ -3,15 +3,15 @@ package net.id.incubus_core.systems;
 import net.fabricmc.fabric.api.event.registry.FabricRegistryBuilder;
 import net.id.incubus_core.IncubusCore;
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.util.Identifier;
 
 public final class RegistryRegistry {
 
     public static void init() {}
 
-    // TODO THIS MATERIAL REGISTRY WAS CHANGED FOR THE 1.18.2 UPDATE. MIGHT BE WRONG.
-    // TODO - Materials were REMOVED for 1.20, this needs to go
-    // public static final RegistryKey<Registry<Material>> MATERIAL_REGISTRY_KEY = RegistryKey.ofRegistry(new Identifier(IncubusCore.MODID, "material"));
-    public static final Registry<Material> MATERIAL = FabricRegistryBuilder.createSimple(Material.class, IncubusCore.locate("material")).buildAndRegister();
+    public static final RegistryKey<Registry<Material>> MATERIAL_REGISTRY_KEY = RegistryKey.ofRegistry(new Identifier(IncubusCore.MODID, "material"));
+    public static final Registry<Material> MATERIAL = FabricRegistryBuilder.createSimple(MATERIAL_REGISTRY_KEY).buildAndRegister();
     // public static final Registry<Material> MATERIAL = (Registry<Material>) ((MutableRegistry) Registry.REGISTRIES).add(MATERIAL_REGISTRY_KEY, new SimpleRegistry<>(MATERIAL_REGISTRY_KEY, Lifecycle.experimental(), null), Lifecycle.experimental());
 
 }


### PR DESCRIPTION
This PR fixes some building issues with Jitpack, as the script that was previously hosted on `immortaldevs.net` is no longer available.
It also fixes the Material Registry (Registry), which I originally mis-commented due to thinking it was the vanilla block material system. 